### PR TITLE
Fixed copy_expansion increment (*str++ instead of str[i++]) - Argv si…

### DIFF
--- a/expansion/copy_expansion.c
+++ b/expansion/copy_expansion.c
@@ -60,7 +60,7 @@ void	copy_expansion(char *src, char **destination, int src_size)
 			handle_quotes(&src, dest, &i);
 			continue ;
 		}
-		dest[i] = src[i]; 
+		dest[i] = *src++; 
 		i++;
 	}
 	dest[i] = 0;

--- a/expansion/expansion.c
+++ b/expansion/expansion.c
@@ -13,7 +13,7 @@ static int	is_expandable(char *str)
 	return (0);
 }
 
-static void	perform_expansion(char *src, char **dest)
+void	perform_expansion(char *src, char **dest)
 {
 	int i;
 

--- a/expansion/expansion.h
+++ b/expansion/expansion.h
@@ -9,5 +9,6 @@ char	**expansion(t_execcmd *execcmd);
 char	*expand_dollar(char **src, int *i);
 int		get_expansion_len(char *src);
 void	copy_expansion(char *src, char **destination, int src_size);
+void	perform_expansion(char *src, char **dest);
 
 #endif

--- a/runcmd/parse.c
+++ b/runcmd/parse.c
@@ -6,7 +6,7 @@
 /*   By: zali <zali@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 16:36:13 by zali              #+#    #+#             */
-/*   Updated: 2025/07/27 14:48:00 by zali             ###   ########.fr       */
+/*   Updated: 2025/08/03 14:19:51 by zali             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,28 @@ static t_cmd	*parseredirects(t_cmd *cmd, char **str, char *end_str)
 	return (cmd);
 }
 
+void	double_argv_size(t_execcmd *cmd)
+{
+	char	**new_argv;
+	char	**new_eargv;
+	int		i;
+
+	new_argv = safe_malloc(sizeof(char *) * (cmd->max_size * 2));
+	new_eargv = safe_malloc(sizeof(char *) * (cmd->max_size * 2));
+	i = 0;
+	while (i < cmd->max_size)
+	{
+		new_argv[i] = cmd->argv[i];
+		new_eargv[i] = cmd->eargv[i];
+		i++;
+	}
+	cmd->max_size *= 2;
+	free(cmd->argv);
+	free(cmd->eargv);
+	cmd->argv = new_argv;
+	cmd->eargv = new_eargv;
+}
+
 static t_cmd	*parsestr(char **str, char *end_str)
 {
 	int			argc;
@@ -92,8 +114,8 @@ static t_cmd	*parsestr(char **str, char *end_str)
 		exec_cmd->eargv[argc] = end_ptr; 
 		exec_cmd->size++;
 		argc++;
-		if (argc >= MAX_SIZE)
-			exit(EXIT_FAILURE); // Proper exit func
+		if (argc == MAX_SIZE)
+			double_argv_size(exec_cmd);
 		ret = parseredirects(ret, str, end_str); 
 	}
 	exec_cmd->argv[argc] = 0;

--- a/runcmd/runcmd.c
+++ b/runcmd/runcmd.c
@@ -6,7 +6,7 @@
 /*   By: zali <zali@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/12 13:30:06 by zali              #+#    #+#             */
-/*   Updated: 2025/07/25 14:08:56 by zali             ###   ########.fr       */
+/*   Updated: 2025/08/03 14:18:34 by zali             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,8 @@ static void	free_trees(t_cmd *cmd)
 {
 	if (cmd->type == EXEC)
 	{
+		free(((t_execcmd *) cmd)->argv);
+		free(((t_execcmd *) cmd)->eargv);
 		free(cmd);
 		cmd = NULL;
 		return ;
@@ -77,7 +79,7 @@ void	run_cmd(char *str, char **envp)
 
 	end_str = str + ft_strlen(str);
 	cmd = parsecmd(str, end_str);
-//	printf("PTR in fork: %s\n", str);
+	// printf("PTR in fork: %s\n", str);
 	//show_cmd_tree(cmd);
 	exec_tree(cmd, envp, 0);
 	free_trees(cmd);

--- a/runcmd/runcmd.h
+++ b/runcmd/runcmd.h
@@ -1,7 +1,7 @@
 #ifndef RUNCMD_H
 
 # define RUNCMD_H
-# define MAX_SIZE 15
+# define MAX_SIZE 2
 
 #include "../libft/includes/libft.h"
 #include "../minishell.h"
@@ -15,8 +15,9 @@ enum {
 typedef	struct execcmd
 {
 	int		type;
-	char	*argv[MAX_SIZE];
-	char	*eargv[MAX_SIZE];
+	char	**argv;
+	char	**eargv;
+	int		max_size;
 	int		size;
 }	t_execcmd;
 

--- a/runcmd/struct_inits.c
+++ b/runcmd/struct_inits.c
@@ -6,7 +6,7 @@
 /*   By: zali <zali@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 16:39:05 by zali              #+#    #+#             */
-/*   Updated: 2025/07/27 14:55:37 by zali             ###   ########.fr       */
+/*   Updated: 2025/08/02 19:19:27 by zali             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,9 @@ t_cmd	*init_t_execcmd(void)
 	execcmd = malloc(sizeof(t_execcmd));
 	execcmd->type = EXEC;
 	execcmd->size = 0;
+	execcmd->max_size = MAX_SIZE;
+	execcmd->argv = safe_malloc(sizeof(char *) * MAX_SIZE);
+	execcmd->eargv = safe_malloc(sizeof(char *) * MAX_SIZE);
 	return ((t_cmd *)execcmd);
 }
 


### PR DESCRIPTION
1. Added Double_argv_size to accept more than x amount of args in exec.
2. Fixed a bug in copy expansion which was incrementing with str[i++] which was meant to be *str++;